### PR TITLE
update netty to 4.1.0-Beta8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,8 @@ libraryDependencies += "com.xeiam.xchange" % "xchange-bitfinex" % "3.1.0"
 libraryDependencies += "com.xeiam.xchange" % "xchange-okcoin" % "3.1.0"
 libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.3.0"
 
+dependencyOverrides += "io.netty" % "netty-all" % "4.1.0.Beta8"
+
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.6" % "test"
 
 enablePlugins(GitVersioning)


### PR DESCRIPTION
Fixes warning about `Failed to find a usable hardware address from
the network interfaces` which only happens on EC2.
