### PR TITLE
Akka dispatcher config (try two)

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,0 +1,23 @@
+dispatcher {
+  type = Dispatcher
+  executor = "fork-join-executor"
+  fork-join-executor {
+    parallelism-min = 6
+    parallelism-factor = 6.0
+    parallelism-max = 20
+  }
+
+  # Throughput defines the maximum number of messages to be
+  # processed per actor before the thread jumps to the next actor.
+  # Set to 1 for as fair as possible.
+  throughput = 1
+}
+
+akka.actor.deployment {
+  "/polling/*" {
+    dispatcher = dispatcher
+  }
+  "/streaming/*" {
+    dispatcher = dispatcher
+  }
+}


### PR DESCRIPTION
Retry of #13.

Better parallelism settings and fair throughput.
