### PR TITLE
[Docker] pass JAVA_OPTS to JVM using shell entrypoint

### DIFF
--- a/docker.sbt
+++ b/docker.sbt
@@ -23,7 +23,7 @@ dockerfile in docker := {
     from("java")
     add(classpath.files, "/app/")
     add(jarFile, jarTarget)
-    entryPoint("java", "-cp", classpathString, mainclass)
+    entryPointShell("exec", "java", "$JAVA_OPTS", "-cp", classpathString, mainclass)
   }
 }
 


### PR DESCRIPTION
See [Docker Shell form ENTRYPOINT example](https://docs.docker.com/engine/reference/builder/#shell-form-entrypoint-example).
