### PR TITLE
[Streaming] disable OKCoin streaming

### DIFF
--- a/src/main/resources/META-INF/services/com.xeiam.xchange.service.streaming.ExchangeStreamingConfiguration
+++ b/src/main/resources/META-INF/services/com.xeiam.xchange.service.streaming.ExchangeStreamingConfiguration
@@ -1,2 +1,1 @@
 com.xeiam.xchange.bitstamp.service.streaming.BitstampStreamingConfiguration
-com.xeiam.xchange.okcoin.service.streaming.OkCoinExchangeStreamingConfiguration


### PR DESCRIPTION
Implementation from XChange is inefficient and incomplete. Specifically,
there is no way to disconnect. Also, OKCoin provides JSON, and serialization
to XChange objects is unnecessary.
