### PR TITLE
change test log4j log level from WARN to ERROR

### DIFF
--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=WARN, stdout
+log4j.rootLogger=ERROR, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
`sbt test` had excessive unnecessary output.
