### PR TITLE
[Polling] move periodic scheduling from constructor to receive

### DIFF
--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/PollingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/PollingActor.scala
@@ -9,6 +9,10 @@ class PollingActor extends Actor {
   val bitfinex = context.actorOf(Props[BitfinexPollingActor], "bitfinex")
   val okcoin = context.actorOf(Props[OKCoinPollingActor], "okcoin")
 
+  bitfinex ! "start"
+  bitstamp ! "start"
+  okcoin ! "start"
+
   def receive = {
     case _ =>
   }

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/BitfinexPollingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/BitfinexPollingActor.scala
@@ -40,7 +40,7 @@ class BitfinexPollingActor extends HTTPPollingActor with ProducerBehavior {
     ("orderbook", Utils.orderBookToJson(None, t, asks, bids))
   }
 
-  def receive = producerBehavior orElse {
+  def receive = periodicBehavior orElse producerBehavior orElse {
     case "tick" =>
       request("/v1/pubticker/btcusd")
         .via(tickFlow)

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/BitstampPollingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/BitstampPollingActor.scala
@@ -37,7 +37,7 @@ class BitstampPollingActor extends HTTPPollingActor with ProducerBehavior {
     ("orderbook", orderbook)
   }
 
-  def receive = producerBehavior orElse {
+  def receive = periodicBehavior orElse producerBehavior orElse {
     case "tick" =>
       request("/api/ticker/")
         .via(tickFlow)

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/HTTPPollingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/HTTPPollingActor.scala
@@ -5,15 +5,12 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 import java.time.Instant
 
-import akka.actor.{Actor, ActorLogging}
+import akka.actor.{Actor, ActorLogging, Cancellable}
 import akka.http.scaladsl.Http.HostConnectionPool
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, ResponseEntity}
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Flow, Sink, Source}
-import co.coinsmith.kafka.cryptocoin.producer.Producer
 import org.json4s.DefaultFormats
-import org.json4s.JsonAST.JValue
-import org.json4s.jackson.JsonMethods._
 
 
 abstract class HTTPPollingActor extends Actor with ActorLogging {
@@ -22,8 +19,6 @@ abstract class HTTPPollingActor extends Actor with ActorLogging {
   implicit val formats = DefaultFormats
   implicit val materializer = ActorMaterializer()
   import context.dispatcher
-  val tick = context.system.scheduler.schedule(2 seconds, 30 seconds, self, "tick")
-  val orderbook = context.system.scheduler.schedule(2 seconds, 30 seconds, self, "orderbook")
 
   val responseFlow = Flow[(Try[HttpResponse], String)].map {
     case (Success(HttpResponse(statusCode, _, entity, _)), _) =>
@@ -45,4 +40,10 @@ abstract class HTTPPollingActor extends Actor with ActorLogging {
     Source.single(HttpRequest(uri = uri) -> "")
       .via(pool)
       .via(responseFlow)
+
+  val periodicBehavior : Receive = {
+    case "start" =>
+      context.system.scheduler.schedule(2 seconds, 30 seconds, self, "tick")
+      context.system.scheduler.schedule(2 seconds, 30 seconds, self, "orderbook")
+  }
 }

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/HTTPPollingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/HTTPPollingActor.scala
@@ -5,7 +5,7 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 import java.time.Instant
 
-import akka.actor.{Actor, ActorLogging, Cancellable}
+import akka.actor.{Actor, ActorLogging}
 import akka.http.scaladsl.Http.HostConnectionPool
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, ResponseEntity}
 import akka.stream.ActorMaterializer

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/OKCoinPollingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/OKCoinPollingActor.scala
@@ -34,7 +34,7 @@ class OKCoinPollingActor extends HTTPPollingActor with ProducerBehavior {
     ("orderbook", json)
   }
 
-  def receive = producerBehavior orElse {
+  def receive = periodicBehavior orElse producerBehavior orElse {
     case "tick" =>
       request("/api/v1/ticker.do?symbol=btc_cny")
         .via(tickFlow)

--- a/src/test/scala/polling/BitfinexPollingActorSpec.scala
+++ b/src/test/scala/polling/BitfinexPollingActorSpec.scala
@@ -19,8 +19,6 @@ class BitfinexPollingActorSpec
 
   val actorRef = TestActorRef[BitfinexPollingActor]
   val actor = actorRef.underlyingActor
-  actor.tick.cancel
-  actor.orderbook.cancel
 
   "BitfinexPollingActor" should "process a ticker message" in {
     val timeCollected = Instant.ofEpochSecond(10L)

--- a/src/test/scala/polling/BitstampPollingActorSpec.scala
+++ b/src/test/scala/polling/BitstampPollingActorSpec.scala
@@ -19,8 +19,6 @@ class BitstampPollingActorSpec
 
   val actorRef = TestActorRef[BitstampPollingActor]
   val actor = actorRef.underlyingActor
-  actor.tick.cancel
-  actor.orderbook.cancel
 
   "BitstampPollingActor" should "process a ticker message" in {
     val timeCollected = Instant.ofEpochSecond(10L)

--- a/src/test/scala/polling/OKCoinPollingActorSpec.scala
+++ b/src/test/scala/polling/OKCoinPollingActorSpec.scala
@@ -17,8 +17,6 @@ class OKCoinPollingActorSpec
 
   val actorRef = TestActorRef[OKCoinPollingActor]
   val actor = actorRef.underlyingActor
-  actor.tick.cancel
-  actor.orderbook.cancel
 
   "OKCoinPollingActor" should "process a ticker message" in {
     val timeCollected = Instant.ofEpochSecond(10L)


### PR DESCRIPTION
Allows polling tests to not hit the network.
