### PR TITLE
[Streaming][Bitstamp] fix old connect message in reconnect logic

### DIFF
--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/BitstampStreamingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/BitstampStreamingActor.scala
@@ -24,7 +24,7 @@ class BitstampStreamingActor extends Actor with ActorLogging with ProducerBehavi
     override def onConnectionStateChange(change: ConnectionStateChange) = {
       log.info("State changed from " + change.getPreviousState + " to " + change.getCurrentState)
       change.getCurrentState match {
-        case ConnectionState.DISCONNECTED => self ! "connect"
+        case ConnectionState.DISCONNECTED => self ! Connect
         case _ =>
       }
     }


### PR DESCRIPTION
Usage of strings as actor messages is easy to forget.
