### PR TITLE
re-enable parallel running of tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,8 +25,6 @@ resolvers ++= Seq(
   "Confluent Maven Repo" at "http://packages.confluent.io/maven/"
 )
 
-parallelExecution in Test := false
-
 enablePlugins(GitVersioning)
 enablePlugins(DockerPlugin)
 


### PR DESCRIPTION
Previously disabled for Kafka integration testing.
