### PR TITLE
[Streaming] log websocket close reason

### DIFF
--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/WebsocketActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/WebsocketActor.scala
@@ -33,6 +33,10 @@ class WebsocketActor(uri: URI) extends Actor with ActorLogging {
         case ex: Exception => throw ex
       }
     }
+
+    override def onClose(session: Session, closeReason: CloseReason) = {
+      log.warning("Websocket disconnected. Reason: {}", closeReason)
+    }
   }
 
   val reconnectHandler = new ReconnectHandler {


### PR DESCRIPTION
Log level of `WARN`. This is intended to be the production log level.
