### PR TITLE
Revert "[Streaming][Bitfinex] throw exception on info event with code 20051"

### DIFF
--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/BitfinexStreamingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/BitfinexStreamingActor.scala
@@ -13,8 +13,6 @@ import org.json4s.JsonDSL.WithBigDecimal._
 import org.json4s.jackson.JsonMethods._
 
 
-case class BitfinexRestartException(message: String) extends Exception(message)
-
 class BitfinexWebsocketProtocol extends Actor with ActorLogging {
   implicit val formats = DefaultFormats
 
@@ -58,16 +56,6 @@ class BitfinexWebsocketProtocol extends Actor with ActorLogging {
     case _ => throw new Exception(s"Trade snapshot processing error for $trade")
   }
 
-  def handleEvent(event: JObject) = {
-    val JObject(JField("event", JString(name)) :: data) = event
-    (name, data) match {
-      case ("info", ("code", JInt(code)) :: ("msg", JString(msg)) :: Nil) if code == 20051 =>
-        throw new BitfinexRestartException(msg)
-      case _ =>
-        log.info("Received event message: {}", compact(render(event)))
-    }
-  }
-
   def receive = {
     case (t, JObject(JField("event", JString("subscribed")) ::
                      JField("channel", JString(channelName)) ::
@@ -75,8 +63,8 @@ class BitfinexWebsocketProtocol extends Actor with ActorLogging {
                      xs)) =>
       log.info("Received subscription event response for channel {} with ID {}", channelName, channelId)
       subscribed += (channelId -> channelName)
-    case (t, event: JObject) if isEvent(event) =>
-      handleEvent(event)
+    case (t, event: JValue) if isEvent(event) =>
+      log.info("Received event message: {}", compact(render(event)))
     case (t: Instant, JArray(JInt(channelId) :: JString("hb") :: Nil)) =>
       log.debug("Received heartbeat message for channel ID {}", channelId)
     case (t: Instant, JArray(JInt(channelId) :: JArray(data) :: Nil)) =>

--- a/src/test/scala/co/coinsmith/kafka/cryptocoin/streaming/BitfinexWebsocketProtocolSpec.scala
+++ b/src/test/scala/co/coinsmith/kafka/cryptocoin/streaming/BitfinexWebsocketProtocolSpec.scala
@@ -13,7 +13,7 @@ class BitfinexWebsocketProtocolSpec extends ExchangeProtocolActorSpec(ActorSyste
     val actor = actorRef.underlyingActor
 
     val timeCollected = Instant.ofEpochSecond(10L)
-    val json = ("event" -> "subscribed") ~
+    val msg = ("event" -> "subscribed") ~
       ("channel" ->"book") ~
       ("chanId" -> 67) ~
       ("prec" -> "R0") ~
@@ -21,20 +21,7 @@ class BitfinexWebsocketProtocolSpec extends ExchangeProtocolActorSpec(ActorSyste
       ("len" -> "100") ~
       ("pair" -> "BTCUSD")
 
-    actorRef ! (timeCollected, json)
+    actorRef ! (timeCollected, msg)
     assert(actor.subscribed == Map(BigInt(67) -> "book"))
-  }
-
-  it should "throw an exception on info event with code 20051" in {
-    val actorRef = TestActorRef[BitfinexWebsocketProtocol]
-    val actor = actorRef.underlyingActor
-
-    val timeCollected = Instant.ofEpochSecond(10L)
-    val json = ("event" -> "info") ~
-      ("code" -> 20051) ~
-      ("msg" -> "Stopping. Please try to reconnect")
-
-    val msg = (timeCollected, json)
-    intercept[BitfinexRestartException](actorRef.receive(msg)).getMessage should include("Stopping. Please try to reconnect")
   }
 }

--- a/src/test/scala/co/coinsmith/kafka/cryptocoin/streaming/ExchangeProtocolActorSpec.scala
+++ b/src/test/scala/co/coinsmith/kafka/cryptocoin/streaming/ExchangeProtocolActorSpec.scala
@@ -2,11 +2,11 @@ package co.coinsmith.kafka.cryptocoin.streaming
 
 import akka.actor.ActorSystem
 import akka.testkit.{ImplicitSender, TestKit}
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike}
 
 
 abstract class ExchangeProtocolActorSpec(_system: ActorSystem) extends TestKit(_system)
-  with FlatSpecLike with BeforeAndAfterAll with Matchers with ImplicitSender {
+  with FlatSpecLike with BeforeAndAfterAll with ImplicitSender {
   override def afterAll {
     TestKit.shutdownActorSystem(system)
   }


### PR DESCRIPTION
Reverts blbradley/kafka-cryptocoin#103

`BitfinexWebsocketProtocol` restarts, but the coupling with `BitfinexStreamingActor` makes multiple websocket actor instances.