### PR TITLE
check for Schema Registry reachability at startup

### DIFF
--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/KafkaCryptocoin.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/KafkaCryptocoin.scala
@@ -1,11 +1,40 @@
 package co.coinsmith.kafka.cryptocoin
 
+import java.io.IOException
+import java.net.{MalformedURLException, URL}
+
 import akka.actor.{ActorSystem, Props}
+import akka.event.Logging
+import com.typesafe.config.ConfigFactory
 
 
 object KafkaCryptocoin {
   implicit val system = ActorSystem("KafkaCryptocoinSystem")
+  val log = Logging(system.eventStream, this.getClass.getName)
+
+  val conf = ConfigFactory.load
+  val schemaRegistryUrl = conf.getString("kafka.cryptocoin.schema-registry-url")
+
+  def isSchemaRegistryAvailable: Boolean = {
+    val connection = new URL(schemaRegistryUrl).openConnection
+    try {
+      connection.connect
+      return true
+    } catch  {
+      case e: MalformedURLException =>
+        throw new RuntimeException("Schema Registry URL is malformed.")
+      case e: IOException =>
+        log.error(e, "Schema registry at {} is unreachable.", schemaRegistryUrl)
+        return false
+    }
+  }
+
   def main(args: Array[String]) {
+    while(isSchemaRegistryAvailable == false) {
+      log.info("Retrying connection to schema registry in five seconds.")
+      Thread.sleep(5000)
+    }
+
     val streamingActor = system.actorOf(Props[StreamingActor], "streaming")
     val pollingActor = system.actorOf(Props[PollingActor], "polling")
   }

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/KafkaCryptocoin.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/KafkaCryptocoin.scala
@@ -31,8 +31,8 @@ object KafkaCryptocoin {
 
   def main(args: Array[String]) {
     while(isSchemaRegistryAvailable == false) {
-      log.info("Retrying connection to schema registry in five seconds.")
-      Thread.sleep(5000)
+      log.info("Retrying connection to schema registry in three seconds.")
+      Thread.sleep(3000)
     }
 
     val streamingActor = system.actorOf(Props[StreamingActor], "streaming")


### PR DESCRIPTION
This requirement came from trying to make a simple Docker Compose file. Schema Registry does not start up in time to respond to requests from this app. I've chose to check for an open socket for now.