### PR TITLE
unique ID per producer

### DIFF
--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/models.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/models.scala
@@ -8,12 +8,12 @@ import co.coinsmith.kafka.cryptocoin.avro.GlobalScaleAndPrecision._
 import com.sksamuel.avro4s.RecordFormat
 
 
-case class ProducerKey(exchange: String, uuid: UUID)
+case class ProducerKey(producerUUID: UUID, exchange: String)
 object ProducerKey {
   val format = RecordFormat[ProducerKey]
 }
 
-case class ExchangeEvent(timestamp: Instant, exchange: String, data: String, uuid: UUID)
+case class ExchangeEvent(timestamp: Instant, producerUUID: UUID, exchange: String, data: String)
 object ExchangeEvent {
   val format = RecordFormat[ExchangeEvent]
 }

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/models.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/models.scala
@@ -1,13 +1,19 @@
 package co.coinsmith.kafka.cryptocoin
 
 import java.time.Instant
+import java.util.UUID
 
 import co.coinsmith.kafka.cryptocoin.avro.InstantTypeMaps._
 import co.coinsmith.kafka.cryptocoin.avro.GlobalScaleAndPrecision._
 import com.sksamuel.avro4s.RecordFormat
 
 
-case class ExchangeEvent(timestamp: Instant, exchange: String, data: String)
+case class ProducerKey(exchange: String, uuid: UUID)
+object ProducerKey {
+  val format = RecordFormat[ProducerKey]
+}
+
+case class ExchangeEvent(timestamp: Instant, exchange: String, data: String, uuid: UUID)
 object ExchangeEvent {
   val format = RecordFormat[ExchangeEvent]
 }

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/HTTPPollingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/HTTPPollingActor.scala
@@ -33,7 +33,7 @@ abstract class HTTPPollingActor extends Actor with ActorLogging {
       val timeCollected = Instant.now
       log.debug("Request returned status code {} with entity {}",  statusCode, entity)
       val msg = responseEntityToString(entity)
-      msg.map(s => ExchangeEvent(timeCollected, exchange, s, Producer.uuid))
+      msg.map(s => ExchangeEvent(timeCollected, Producer.uuid, exchange, s))
     case (Failure(response), _) =>
       throw new Exception(s"Request failed with response ${response}")
   }

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/HTTPPollingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/HTTPPollingActor.scala
@@ -33,7 +33,7 @@ abstract class HTTPPollingActor extends Actor with ActorLogging {
       val timeCollected = Instant.now
       log.debug("Request returned status code {} with entity {}",  statusCode, entity)
       val msg = responseEntityToString(entity)
-      msg.map(s => ExchangeEvent(timeCollected, exchange, s))
+      msg.map(s => ExchangeEvent(timeCollected, exchange, s, Producer.uuid))
     case (Failure(response), _) =>
       throw new Exception(s"Request failed with response ${response}")
   }

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/producer/Producer.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/producer/Producer.scala
@@ -1,11 +1,13 @@
 package co.coinsmith.kafka.cryptocoin.producer
 
-import java.util.Properties
+import java.util.{Properties, UUID}
 
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 
 object Producer {
+  val uuid = UUID.randomUUID
+
   val conf = ConfigFactory.load
   val brokers = conf.getString("kafka.cryptocoin.bootstrap-servers")
   val schemaRegistryUrl = conf.getString("kafka.cryptocoin.schema-registry-url")

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/BitfinexStreamingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/BitfinexStreamingActor.scala
@@ -169,8 +169,9 @@ class BitfinexStreamingActor extends Actor with ActorLogging {
       Producer.send(topicPrefix + topic, value)
     case (t: Instant, msg: String) =>
       val exchange = "bitfinex"
-      val event = ExchangeEvent(t, exchange, msg)
-      Producer.send("streaming.websocket.raw", exchange, ExchangeEvent.format.to(event))
+      val key = ProducerKey(exchange, Producer.uuid)
+      val event = ExchangeEvent(t, exchange, msg, Producer.uuid)
+      Producer.send("streaming.websocket.raw", ProducerKey.format.to(key), ExchangeEvent.format.to(event))
 
       protocol ! (t, parse(msg))
   }

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/BitfinexStreamingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/BitfinexStreamingActor.scala
@@ -169,8 +169,8 @@ class BitfinexStreamingActor extends Actor with ActorLogging {
       Producer.send(topicPrefix + topic, value)
     case (t: Instant, msg: String) =>
       val exchange = "bitfinex"
-      val key = ProducerKey(exchange, Producer.uuid)
-      val event = ExchangeEvent(t, exchange, msg, Producer.uuid)
+      val key = ProducerKey(Producer.uuid, exchange)
+      val event = ExchangeEvent(t, Producer.uuid, exchange, msg)
       Producer.send("streaming.websocket.raw", ProducerKey.format.to(key), ExchangeEvent.format.to(event))
 
       protocol ! (t, parse(msg))

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/BitstampStreamingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/BitstampStreamingActor.scala
@@ -144,7 +144,7 @@ class BitstampStreamingActor extends Actor with ActorLogging {
       Producer.send(topicPrefix + topic, value)
     case pe : PusherEvent =>
       val key = ProducerKey(Producer.uuid, "bitstamp")
-      Producer.send("streaming.websocket.raw", ProducerKey.format.to(key), PusherEvent.format.to(pe))
+      Producer.send("streaming.pusher.raw", ProducerKey.format.to(key), PusherEvent.format.to(pe))
 
       if (preprocess) {
         protocol ! pe

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/BitstampStreamingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/BitstampStreamingActor.scala
@@ -3,7 +3,7 @@ package co.coinsmith.kafka.cryptocoin.streaming
 import java.time.Instant
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Props}
-import co.coinsmith.kafka.cryptocoin.{Order, OrderBook, Trade}
+import co.coinsmith.kafka.cryptocoin.{Order, OrderBook, ProducerKey, Trade}
 import co.coinsmith.kafka.cryptocoin.avro.InstantTypeMaps._
 import co.coinsmith.kafka.cryptocoin.producer.Producer
 import com.pusher.client.Pusher
@@ -142,7 +142,8 @@ class BitstampStreamingActor extends Actor with ActorLogging {
     case (topic: String, value: Object) =>
       Producer.send(topicPrefix + topic, value)
     case pe : PusherEvent =>
-      Producer.send("streaming.pusher.raw", "bitstamp", PusherEvent.format.to(pe))
+      val key = ProducerKey("bitstamp", Producer.uuid)
+      Producer.send("streaming.websocket.raw", ProducerKey.format.to(key), PusherEvent.format.to(pe))
 
       if (preprocess) {
         protocol ! pe

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/OKCoinStreamingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/OKCoinStreamingActor.scala
@@ -129,8 +129,8 @@ class OKCoinStreamingActor extends Actor with ActorLogging {
       Producer.send(topicPrefix + topic, value)
     case (t: Instant, msg: String) =>
       val exchange = "okcoin"
-      val key = ProducerKey(exchange, Producer.uuid)
-      val event = ExchangeEvent(t, exchange, msg, Producer.uuid)
+      val key = ProducerKey(Producer.uuid, exchange)
+      val event = ExchangeEvent(t, Producer.uuid, exchange, msg)
       Producer.send("streaming.websocket.raw", ProducerKey.format.to(key), ExchangeEvent.format.to(event))
 
       protocol ! (t, parse(msg))

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/OKCoinStreamingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/streaming/OKCoinStreamingActor.scala
@@ -129,8 +129,9 @@ class OKCoinStreamingActor extends Actor with ActorLogging {
       Producer.send(topicPrefix + topic, value)
     case (t: Instant, msg: String) =>
       val exchange = "okcoin"
-      val event = ExchangeEvent(t, exchange, msg)
-      Producer.send("streaming.websocket.raw", exchange, ExchangeEvent.format.to(event))
+      val key = ProducerKey(exchange, Producer.uuid)
+      val event = ExchangeEvent(t, exchange, msg, Producer.uuid)
+      Producer.send("streaming.websocket.raw", ProducerKey.format.to(key), ExchangeEvent.format.to(event))
 
       protocol ! (t, parse(msg))
   }

--- a/src/test/scala/co/coinsmith/kafka/cryptocoin/polling/BitfinexPollingActorSpec.scala
+++ b/src/test/scala/co/coinsmith/kafka/cryptocoin/polling/BitfinexPollingActorSpec.scala
@@ -1,6 +1,7 @@
 package co.coinsmith.kafka.cryptocoin.polling
 
 import java.time.Instant
+import java.util.UUID
 
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
@@ -23,13 +24,14 @@ class BitfinexPollingActorSpec
   "BitfinexPollingActor" should "process a ticker message" in {
     val timeCollected = Instant.ofEpochSecond(10L)
     val timestamp = Instant.ofEpochSecond(1461608354L, 95383854L)
+    val uuid = UUID.randomUUID
     val json = ("mid" -> "464.845") ~
       ("bid" -> "464.8") ~
       ("ask" -> "464.89") ~
       ("last_price" -> "464.9") ~
       ("timestamp" -> "1461608354.095383854")
     val data = compact(render(json))
-    val event = ExchangeEvent(timeCollected, actor.exchange, data)
+    val event = ExchangeEvent(timeCollected, uuid, actor.exchange, data)
 
     val expected = Tick(464.9, 464.8, 464.89, timeCollected, timestamp = Some(timestamp))
 
@@ -44,6 +46,7 @@ class BitfinexPollingActorSpec
 
   it should "process an orderbook message" in {
     val timeCollected = Instant.ofEpochSecond(10L)
+    val uuid = UUID.randomUUID
     val json = ("bids" -> List(
       ("price" -> "464.11") ~ ("amount" -> "43.98077206") ~ ("timestamp" -> "1461607939.0"),
       ("price" -> "463.87") ~ ("amount" -> "21.3389") ~ ("timestamp" -> "1461607927.0"),
@@ -54,7 +57,7 @@ class BitfinexPollingActorSpec
       ("price" -> "464.63") ~ ("amount" -> "4.07481358") ~ ("timestamp" -> "1461607944.0")
     ))
     val data = compact(render(json))
-    val event = ExchangeEvent(timeCollected, actor.exchange, data)
+    val event = ExchangeEvent(timeCollected, uuid, actor.exchange, data)
 
     val bids = List(
       Order(464.11, 43.98077206, timestamp = Some(Instant.ofEpochSecond(1461607939L))),

--- a/src/test/scala/co/coinsmith/kafka/cryptocoin/polling/BitstampPollingActorSpec.scala
+++ b/src/test/scala/co/coinsmith/kafka/cryptocoin/polling/BitstampPollingActorSpec.scala
@@ -1,6 +1,7 @@
 package co.coinsmith.kafka.cryptocoin.polling
 
 import java.time.Instant
+import java.util.UUID
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.ContentTypes
@@ -24,6 +25,7 @@ class BitstampPollingActorSpec
   "BitstampPollingActor" should "process a ticker message" in {
     val timeCollected = Instant.ofEpochSecond(10L)
     val timestamp = Instant.ofEpochSecond(1459297128)
+    val uuid = UUID.randomUUID
     val json = ("high" ->  "424.37") ~
       ("last" -> "415.24") ~
       ("timestamp" -> timestamp.getEpochSecond.toString) ~
@@ -34,7 +36,7 @@ class BitstampPollingActorSpec
       ("ask" -> "415.24") ~
       ("open" -> 415.43)
     val data = compact(render(json))
-    val event = ExchangeEvent(timeCollected, actor.exchange, data)
+    val event = ExchangeEvent(timeCollected, uuid, actor.exchange, data)
 
     val expected = Tick(
       415.24, 414.34, 415.24, timeCollected,
@@ -54,6 +56,7 @@ class BitstampPollingActorSpec
 
   it should "process an orderbook message" in {
     val timeCollected = Instant.ofEpochSecond(10L)
+    val uuid = UUID.randomUUID
     val timestamp = 1461605735L
     val json = ("timestamp" -> timestamp.toString) ~
       ("bids" -> List(
@@ -67,7 +70,7 @@ class BitstampPollingActorSpec
       ))
     val contentType = ContentTypes.`application/json`
     val data = compact(render(json))
-    val event = ExchangeEvent(timeCollected, actor.exchange, data)
+    val event = ExchangeEvent(timeCollected, uuid, actor.exchange, data)
 
     val bids = List(
       Order("462.49", "0.03010000"),

--- a/src/test/scala/co/coinsmith/kafka/cryptocoin/polling/OKCoinPollingActorSpec.scala
+++ b/src/test/scala/co/coinsmith/kafka/cryptocoin/polling/OKCoinPollingActorSpec.scala
@@ -1,6 +1,7 @@
 package co.coinsmith.kafka.cryptocoin.polling
 
 import java.time.Instant
+import java.util.UUID
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.ContentTypes
@@ -24,6 +25,7 @@ class OKCoinPollingActorSpec
   "OKCoinPollingActor" should "process a ticker message" in {
     val timeCollected = Instant.ofEpochSecond(10L)
     val timestamp = Instant.ofEpochSecond(1462489329L)
+    val uuid = UUID.randomUUID
     val json = ("date" -> timestamp.getEpochSecond.toString) ~ ("ticker" ->
       ("buy" -> "2906.58") ~
         ("high" -> "2915.0")  ~
@@ -33,7 +35,7 @@ class OKCoinPollingActorSpec
         ("vol" ->"635178.4712"))
     val contentType = ContentTypes.`text/html(UTF-8)`
     val data = compact(render(json))
-    val event = ExchangeEvent(timeCollected, actor.exchange, data)
+    val event = ExchangeEvent(timeCollected, uuid, actor.exchange, data)
 
     val expected = Tick(
       2906.64, 2906.58, 2906.63, timeCollected,
@@ -53,6 +55,7 @@ class OKCoinPollingActorSpec
 
   it should "process an orderbook message" in {
     val timeCollected = Instant.ofEpochSecond(10L)
+    val uuid = UUID.randomUUID
     val json = ("asks" -> List(
       List(2915.15, 0.032),
       List(2915.14, 1.701),
@@ -63,7 +66,7 @@ class OKCoinPollingActorSpec
       List(2906.75, 0.082)
     ))
     val data = compact(render(json))
-    val event = ExchangeEvent(timeCollected, actor.exchange, data)
+    val event = ExchangeEvent(timeCollected, uuid, actor.exchange, data)
 
     val bids = List(
       Order(2906.83, 1.912),


### PR DESCRIPTION
Different app deployments can point to the same Kafka cluster.

Unfortunately (or not?), this will make most of the preprocessing code unusable.