### PR TITLE
[Travis CI] update Scala version to 2.12.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.11.8
+  - 2.12.1
 
 branches:
   only:


### PR DESCRIPTION
This was missed on the update in `build.sbt`.