### PR TITLE
[Polling] use Akka HTTP request-level API

### DIFF
--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/BitfinexPollingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/BitfinexPollingActor.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpRequest
-import akka.stream.scaladsl.{Flow, Sink}
+import akka.stream.scaladsl.Flow
 import co.coinsmith.kafka.cryptocoin.producer.Producer
 import co.coinsmith.kafka.cryptocoin.{Order, OrderBook, Tick}
 

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/BitstampPollingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/BitstampPollingActor.scala
@@ -3,9 +3,11 @@ package co.coinsmith.kafka.cryptocoin.polling
 import java.time.Instant
 
 import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
 import akka.stream.scaladsl.{Flow, Sink}
+import akka.util.ByteString
 import co.coinsmith.kafka.cryptocoin.producer.Producer
-import co.coinsmith.kafka.cryptocoin.{Order, OrderBook, Tick}
+import co.coinsmith.kafka.cryptocoin.{ExchangeEvent, Order, OrderBook, Tick}
 
 case class BitstampPollingTick(
   high: String,
@@ -46,9 +48,12 @@ object BitstampPollingOrderBook {
 }
 
 class BitstampPollingActor extends HTTPPollingActor {
+  import akka.pattern.pipe
+  import context.dispatcher
+
   val exchange = "bitstamp"
   val topicPrefix = "bitstamp.polling.btcusd."
-  val pool = Http(context.system).cachedHostConnectionPoolHttps[String]("www.bitstamp.net")
+  val http = Http(context.system)
 
   val tickFlow = Flow[(Instant, BitstampPollingTick)].map { case (t, tick) =>
     implicit val timeCollected = t
@@ -60,28 +65,12 @@ class BitstampPollingActor extends HTTPPollingActor {
     ("orderbook", OrderBook.format.to(ob))
   }
 
-  def receive = periodicBehavior orElse {
+  def receive = periodicBehavior orElse responseBehavior orElse {
     case (topic: String, value: Object) =>
       Producer.send(topicPrefix + topic, value)
     case "tick" =>
-      val req = request("/api/ticker/")
-      if (preprocess) {
-        req.via(convertFlow[BitstampPollingTick])
-          .via(tickFlow)
-          .runWith(selfSink)
-      } else {
-        req.runWith(Sink.ignore)
-      }
-
+      http.singleRequest(HttpRequest(uri = "https://www.bitstamp.net/api/v2/ticker/btcusd/")) pipeTo self
     case "orderbook" =>
-      val req = request("/api/order_book/")
-      if (preprocess) {
-        req.via(convertFlow[BitstampPollingOrderBook])
-          .via(orderbookFlow)
-          .runWith(selfSink)
-      } else {
-        req.runWith(Sink.ignore)
-      }
-
+      http.singleRequest(HttpRequest(uri = "https://www.bitstamp.net/api/v2/order_book/btcusd/")) pipeTo self
   }
 }

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/BitstampPollingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/BitstampPollingActor.scala
@@ -3,11 +3,10 @@ package co.coinsmith.kafka.cryptocoin.polling
 import java.time.Instant
 
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
-import akka.stream.scaladsl.{Flow, Sink}
-import akka.util.ByteString
+import akka.http.scaladsl.model.HttpRequest
+import akka.stream.scaladsl.Flow
 import co.coinsmith.kafka.cryptocoin.producer.Producer
-import co.coinsmith.kafka.cryptocoin.{ExchangeEvent, Order, OrderBook, Tick}
+import co.coinsmith.kafka.cryptocoin.{Order, OrderBook, Tick}
 
 case class BitstampPollingTick(
   high: String,

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/HTTPPollingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/HTTPPollingActor.scala
@@ -2,14 +2,12 @@ package co.coinsmith.kafka.cryptocoin.polling
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
 import java.time.Instant
 
 import akka.actor.{Actor, ActorLogging}
-import akka.http.scaladsl.Http.HostConnectionPool
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse, ResponseEntity, StatusCodes}
+import akka.http.scaladsl.model.{HttpResponse, ResponseEntity, StatusCodes}
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 import co.coinsmith.kafka.cryptocoin.ExchangeEvent
 import co.coinsmith.kafka.cryptocoin.producer.Producer

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/HTTPPollingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/HTTPPollingActor.scala
@@ -7,9 +7,10 @@ import java.time.Instant
 
 import akka.actor.{Actor, ActorLogging}
 import akka.http.scaladsl.Http.HostConnectionPool
-import akka.http.scaladsl.model.{HttpRequest, HttpResponse, ResponseEntity}
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, ResponseEntity, StatusCodes}
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.util.ByteString
 import co.coinsmith.kafka.cryptocoin.ExchangeEvent
 import co.coinsmith.kafka.cryptocoin.producer.Producer
 import com.typesafe.config.ConfigFactory
@@ -19,7 +20,6 @@ import org.json4s.jackson.JsonMethods._
 
 abstract class HTTPPollingActor extends Actor with ActorLogging {
   val exchange: String
-  val pool: Flow[(HttpRequest, String), (Try[HttpResponse], String), HostConnectionPool]
 
   implicit val formats = DefaultFormats
   implicit val materializer = ActorMaterializer()
@@ -28,39 +28,29 @@ abstract class HTTPPollingActor extends Actor with ActorLogging {
   val conf = ConfigFactory.load
   val preprocess = conf.getBoolean("kafka.cryptocoin.preprocess")
 
-  val responseFlow = Flow[(Try[HttpResponse], String)].mapAsync(1) {
-    case (Success(HttpResponse(statusCode, headers, entity, _)), _) =>
-      val timeCollected = Instant.now
-      log.debug("Request returned status code {} with entity {}",  statusCode, entity)
-      val msg = responseEntityToString(entity)
-      msg.map(s => ExchangeEvent(timeCollected, Producer.uuid, exchange, s))
-    case (Failure(response), _) =>
-      throw new Exception(s"Request failed with response ${response}")
-  }
-
-  val rawSink = Sink.foreach[ExchangeEvent] { event =>
-    Producer.send("polling.raw", exchange, ExchangeEvent.format.to(event))
-  }
-
   def responseEntityToString(entity: ResponseEntity): Future[String] =
-    entity.toStrict(500 millis) map { _.data.utf8String }
+    entity.dataBytes.runFold(ByteString(""))(_ ++ _).map(_.utf8String)
   
   def convertFlow[T : Manifest] = Flow[ExchangeEvent].map { e =>
     val json = parse(e.data)
     (e.timestamp, json.extract[T])
   }
 
-  val selfSink = Sink.actorRef(self, None)
-
-  def request(uri: String) =
-    Source.single(HttpRequest(uri = uri) -> "")
-      .via(pool)
-      .via(responseFlow)
-      .alsoTo(rawSink)
-
   val periodicBehavior : Receive = {
     case "start" =>
       context.system.scheduler.schedule(2 seconds, 30 seconds, self, "tick")
       context.system.scheduler.schedule(2 seconds, 30 seconds, self, "orderbook")
+  }
+
+  val responseBehavior : Receive = {
+    case HttpResponse(StatusCodes.OK, headers, entity, _) =>
+      val timeCollected = Instant.now
+      responseEntityToString(entity).foreach { data =>
+        val event = ExchangeEvent(timeCollected, Producer.uuid, exchange, data)
+        Producer.send("polling.raw", exchange, ExchangeEvent.format.to(event))
+      }
+    case response @ HttpResponse(code, _, _, _) =>
+      throw new Exception(s"Request failed with response ${response}")
+      response.discardEntityBytes()
   }
 }

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/OKCoinPollingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/OKCoinPollingActor.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpRequest
-import akka.stream.scaladsl.{Flow, Sink}
+import akka.stream.scaladsl.Flow
 import co.coinsmith.kafka.cryptocoin.producer.Producer
 import co.coinsmith.kafka.cryptocoin.{Order, OrderBook, Tick}
 

--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/OKCoinPollingActor.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/polling/OKCoinPollingActor.scala
@@ -3,6 +3,7 @@ package co.coinsmith.kafka.cryptocoin.polling
 import java.time.Instant
 
 import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.HttpRequest
 import akka.stream.scaladsl.{Flow, Sink}
 import co.coinsmith.kafka.cryptocoin.producer.Producer
 import co.coinsmith.kafka.cryptocoin.{Order, OrderBook, Tick}
@@ -41,9 +42,12 @@ object OKCoinPollingOrderBook {
 }
 
 class OKCoinPollingActor extends HTTPPollingActor {
+  import akka.pattern.pipe
+  import context.dispatcher
+
   val exchange = "okcoin"
   val topicPrefix = "okcoin.polling.btcusd."
-  val pool = Http(context.system).cachedHostConnectionPoolHttps[String]("www.okcoin.cn")
+  val http = Http(context.system)
 
   val tickFlow = Flow[(Instant, OKCoinPollingDatedTick)].map { case (t, tick) =>
     implicit val timeCollected = t
@@ -55,26 +59,12 @@ class OKCoinPollingActor extends HTTPPollingActor {
     ("orderbook", OrderBook.format.to(ob))
   }
 
-  def receive = periodicBehavior orElse {
+  def receive = periodicBehavior orElse responseBehavior orElse {
     case (topic: String, value: Object) =>
       Producer.send(topicPrefix + topic, value)
     case "tick" =>
-      val req = request("/api/v1/ticker.do?symbol=btc_cny")
-      if (preprocess) {
-        req.via(convertFlow[OKCoinPollingDatedTick])
-          .via(tickFlow)
-          .runWith(selfSink)
-      } else {
-        req.runWith(Sink.ignore)
-      }
+      http.singleRequest(HttpRequest(uri = "https://www.okcoin.cn/api/v1/ticker.do?symbol=btc_cny")) pipeTo self
     case "orderbook" =>
-      val req = request("/api/v1/depth.do??symbol=btc_cny")
-      if (preprocess) {
-        req.via(convertFlow[OKCoinPollingOrderBook])
-          .via(orderbookFlow)
-          .runWith(selfSink)
-      } else {
-        req.runWith(Sink.ignore)
-      }
+      http.singleRequest(HttpRequest(uri = "https://www.okcoin.cn/api/v1/depth.do??symbol=btc_cny")) pipeTo self
   }
 }


### PR DESCRIPTION
Using a connection pool was a preoptimization. This is much easier to reason with.

Preprocessing logic activation for polling actors has been removed.