### PR TITLE
properties for internal Producer retires

### DIFF
--- a/src/main/scala/co/coinsmith/kafka/cryptocoin/producer/KafkaCryptocoinProducer.scala
+++ b/src/main/scala/co/coinsmith/kafka/cryptocoin/producer/KafkaCryptocoinProducer.scala
@@ -28,6 +28,9 @@ object KafkaCryptocoinProducer {
 
   val props = new Properties
   props.put("acks", "all")
+  props.put("retires", Int.MaxValue.toString)
+  props.put("max.block.ms", Long.MaxValue.toString)
+  props.put("max.in.flight.requests.per.connection", "1")
 
   val producerConfigPath = "kafka.cryptocoin.producer.config"
   if (conf.hasPath(producerConfigPath)) {


### PR DESCRIPTION
Important settings for less data loss. See [this](https://groups.google.com/d/msg/kafka-clients/lWlRRc5JNmg/F9yAzcbbAAAJ) for a better explanation.